### PR TITLE
Fix EIntOverflow: Arithmetic overflow error

### DIFF
--- a/cef3own.pas
+++ b/cef3own.pas
@@ -2787,9 +2787,12 @@ Var
   exc: ustring;
 begin
   SetLength(args, argumentsCount);
-  For i := 0 to argumentsCount - 1 do
-    args[i] := TCefv8ValueRef.UnWrap(arguments^[i]);
-
+  if (argumentsCount > 0) then
+  begin
+    For i := 0 to argumentsCount - 1 do
+      args[i] := TCefv8ValueRef.UnWrap(arguments^[i]);
+  end;
+  
   Result := -Ord(TCefv8HandlerOwn(CefGetObject(self)).Execute(
     CefString(name), TCefv8ValueRef.UnWrap(object_), args, ret, exc));
   retval := CefGetData(ret);


### PR DESCRIPTION
FPC Ver: 3.1.1
OS: Linux-x86-64

If try to call a custom method with no parameters, you will get this error